### PR TITLE
[feat] 도시 날씨 API 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/site/weather/api/weather/config/WeatherConfig.java
+++ b/src/main/java/site/weather/api/weather/config/WeatherConfig.java
@@ -5,7 +5,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -14,7 +18,8 @@ import site.weather.api.weather.service.WeatherWebClient;
 
 @Configuration
 @RequiredArgsConstructor
-public class WeatherConfig {
+@EnableWebSocketMessageBroker
+public class WeatherConfig implements WebSocketMessageBrokerConfigurer {
 
 	private final ObjectMapper objectMapper;
 
@@ -30,5 +35,18 @@ public class WeatherConfig {
 			})
 			.build();
 		return new WeatherWebClient(webClient, appid);
+	}
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/ws/weather")
+			.setAllowedOrigins("http://localhost:8080")
+			.withSockJS();
+	}
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry config) {
+		config.enableSimpleBroker("/topic");
+		config.setApplicationDestinationPrefixes("/app");
 	}
 }

--- a/src/main/java/site/weather/api/weather/controller/WeatherController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherController.java
@@ -1,23 +1,32 @@
 package site.weather.api.weather.controller;
 
+import java.time.Duration;
+
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 import lombok.RequiredArgsConstructor;
-import reactor.core.publisher.Mono;
-import site.weather.api.weather.dto.response.WeatherResponse;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 import site.weather.api.weather.service.WeatherService;
 
 @Controller
 @RequiredArgsConstructor
+@Slf4j
 public class WeatherController {
 
 	private final WeatherService service;
 
+	private final SimpMessagingTemplate messagingTemplate;
+
 	@MessageMapping("/weather")
-	@SendTo("/topic/weather")
-	public Mono<WeatherResponse> subscribeWeather(String city) {
-		return service.fetchWeatherByCity(city);
+	public void subscribeWeather(String city) {
+		Flux.interval(Duration.ofSeconds(5))
+			.flatMap(tick -> service.fetchWeatherByCity(city))
+			.take(Duration.ofSeconds(30))
+			.publishOn(Schedulers.boundedElastic())
+			.subscribe(response -> messagingTemplate.convertAndSend("/topic/weather", response));
 	}
 }

--- a/src/main/java/site/weather/api/weather/controller/WeatherController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherController.java
@@ -1,0 +1,2 @@
+package site.weather.api.weather.controller;public class WeatherController {
+}

--- a/src/main/java/site/weather/api/weather/controller/WeatherController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherController.java
@@ -1,2 +1,23 @@
-package site.weather.api.weather.controller;public class WeatherController {
+package site.weather.api.weather.controller;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+import site.weather.api.weather.dto.response.WeatherResponse;
+import site.weather.api.weather.service.WeatherService;
+
+@Controller
+@RequiredArgsConstructor
+public class WeatherController {
+
+	private final WeatherService service;
+
+	@MessageMapping("/weather")
+	@SendTo("/topic/weather")
+	public Mono<WeatherResponse> subscribeWeather(String city) {
+		return service.fetchWeatherByCity(city);
+	}
 }

--- a/src/main/java/site/weather/api/weather/controller/WeatherRestController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherRestController.java
@@ -2,7 +2,6 @@ package site.weather.api.weather.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,13 +11,12 @@ import site.weather.api.weather.dto.response.WeatherResponse;
 import site.weather.api.weather.service.WeatherService;
 
 @RestController
-@RequestMapping("/api/weather")
 @RequiredArgsConstructor
 public class WeatherRestController {
 
 	private final WeatherService service;
 
-	@GetMapping
+	@GetMapping("/api/weather")
 	public Mono<ResponseEntity<WeatherResponse>> getWeather(@RequestParam String city) {
 		return service.fetchWeatherByCity(city)
 			.map(ResponseEntity::ok);

--- a/src/main/java/site/weather/api/weather/controller/WeatherRestController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherRestController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
 import site.weather.api.weather.dto.response.WeatherResponse;
 import site.weather.api.weather.service.WeatherService;
 
@@ -18,8 +19,8 @@ public class WeatherRestController {
 	private final WeatherService service;
 
 	@GetMapping
-	public ResponseEntity<WeatherResponse> getWeather(@RequestParam String city) {
-		WeatherResponse response = service.fetchWeatherByCity(city);
-		return ResponseEntity.ok(response);
+	public Mono<ResponseEntity<WeatherResponse>> getWeather(@RequestParam String city) {
+		return service.fetchWeatherByCity(city)
+			.map(ResponseEntity::ok);
 	}
 }

--- a/src/main/java/site/weather/api/weather/dto/response/WeatherResponse.java
+++ b/src/main/java/site/weather/api/weather/dto/response/WeatherResponse.java
@@ -3,14 +3,18 @@ package site.weather.api.weather.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @EqualsAndHashCode
+@NoArgsConstructor
+@Getter
 public class WeatherResponse {
 	@JsonProperty("name")
-	private final String name;
+	private String name;
 	@JsonProperty("temperature")
-	private final double temperature;
-	
+	private double temperature;
+
 	public WeatherResponse(String name, double temperature) {
 		this.name = name;
 		this.temperature = temperature;

--- a/src/main/java/site/weather/api/weather/dto/response/WeatherResponse.java
+++ b/src/main/java/site/weather/api/weather/dto/response/WeatherResponse.java
@@ -3,17 +3,13 @@ package site.weather.api.weather.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @EqualsAndHashCode
-@NoArgsConstructor
-@Getter
 public class WeatherResponse {
 	@JsonProperty("name")
-	private String name;
+	private final String name;
 	@JsonProperty("temperature")
-	private double temperature;
+	private final double temperature;
 
 	public WeatherResponse(String name, double temperature) {
 		this.name = name;

--- a/src/main/java/site/weather/api/weather/service/WeatherService.java
+++ b/src/main/java/site/weather/api/weather/service/WeatherService.java
@@ -3,6 +3,7 @@ package site.weather.api.weather.service;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
 import site.weather.api.weather.dto.response.WeatherResponse;
 
 @Service
@@ -11,7 +12,7 @@ public class WeatherService {
 
 	private final WeatherWebClient client;
 
-	public WeatherResponse fetchWeatherByCity(String city) {
-		return client.fetchWeatherByCity(city).block();
+	public Mono<WeatherResponse> fetchWeatherByCity(String city) {
+		return client.fetchWeatherByCity(city);
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: weather
+  thymeleaf:
+    cache: false
   config:
     import:
       - ./secret/application-secret.yml

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -78,6 +78,8 @@
             margin: 5px 0;
         }
     </style>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
 </head>
 <body>
 
@@ -93,21 +95,20 @@
 
 <script>
     async function getWeather() {
+        const socket = new SockJS('/ws/weather');
+        const stompClient = Stomp.over(socket);
 
-        const city = document.querySelector("#city").value;
-        const resultDiv = document.querySelector("#result");
+        stompClient.connect({}, () => {
+            stompClient.subscribe('/topic/weather', (message) => {
+                const weatherData = JSON.parse(message.body);
+                document.querySelector("#result").innerHTML = `
+                <p>City: ${weatherData.name}</p>
+                <p>Temperature: ${weatherData.temperature}°C</p>`;
+            });
 
-        // API 호출
-        const response = await fetch(`/api/weather?city=${encodeURIComponent(city)}`);
-
-        if (!response.ok) {
-            resultDiv.innerHTML = `<p style="color: red;">Error: ${error.message}</p>`;
-        }
-
-        const data = await response.json();
-
-        // 온도 정보를 표시
-        resultDiv.innerHTML = `<p>City: ${data.name}</p><p>Temperature: ${data.temperature}°C</p>`;
+            // 특정 도시를 구독
+            stompClient.send("/app/weather", {}, "Seoul");
+        });
     }
 </script>
 


### PR DESCRIPTION
## 구현한것
- 기존 REST API 방식에서 WebSocket Stomp 방식으로 개선

## AS-IS
- "/app/weather"로 메시지 요청시 "/topic/weather"를 구독한 클라이언트들에게 총 30초동안 5초 간격으로 날씨 정보를 푸시합니다.

## TO-BE
- 메시지 요청을 받은 컨트롤러에서 5초 간격으로 푸시할때 외부 API에 계속 새로 요청하고 있습니다. 여러 클라이언트에서 메시지 요청하더라도 효율적으로 API 요청할수 있도록 개선