### PR TITLE
[refactor] 도시 날씨 API 개선

### DIFF
--- a/src/main/java/site/weather/api/weather/config/WeatherConfig.java
+++ b/src/main/java/site/weather/api/weather/config/WeatherConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -19,6 +20,7 @@ import site.weather.api.weather.service.WeatherWebClient;
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSocketMessageBroker
+@EnableScheduling
 public class WeatherConfig implements WebSocketMessageBrokerConfigurer {
 
 	private final ObjectMapper objectMapper;

--- a/src/main/java/site/weather/api/weather/controller/WeatherController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherController.java
@@ -23,7 +23,7 @@ public class WeatherController {
 
 	@MessageMapping("/weather")
 	public void subscribeWeather(String city) {
-		repository.computeIfAbsent(city).sendOrFetchWeather(messagingTemplate, city, service::subscribeWeatherByCity);
+		service.computeIfAbsent(city).sendOrFetchWeather(messagingTemplate, city, service::subscribeWeatherByCity);
 	}
 
 	@Scheduled(fixedRate = 30, timeUnit = TimeUnit.SECONDS)

--- a/src/main/java/site/weather/api/weather/controller/WeatherController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherController.java
@@ -25,7 +25,7 @@ public class WeatherController {
 			.sendOrFetchWeather(messagingTemplate, city, service::subscribeWeatherByCity);
 	}
 
-	@Scheduled(fixedRate = 30, timeUnit = TimeUnit.SECONDS)
+	@Scheduled(fixedRate = 5, timeUnit = TimeUnit.SECONDS)
 	public void fetchAndBroadcastByCity() {
 		service.findAllSubscribedCities().forEach(service::subscribeWeatherByCity);
 	}

--- a/src/main/java/site/weather/api/weather/controller/WeatherController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherController.java
@@ -35,15 +35,8 @@ public class WeatherController {
 
 	@MessageMapping("/weather")
 	public void subscribeWeather(String city) {
-		if (weatherSubscriptionInfoMap.containsKey(city)) {
-			if (weatherSubscriptionInfoMap.get(city).hasWeatherResponse()) {
-				weatherSubscriptionInfoMap.get(city).sendMessage(messagingTemplate, city);
-			} else {
-				fetchWeatherByCity(city);
-			}
-		} else {
-			fetchWeatherByCity(city);
-		}
+		weatherSubscriptionInfoMap.computeIfAbsent(city, key -> new WeatherSubscriptionInfo())
+			.sendOrFetchWeather(messagingTemplate, city, this::fetchWeatherByCity);
 	}
 
 	private void fetchWeatherByCity(String city) {

--- a/src/main/java/site/weather/api/weather/controller/WeatherController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherController.java
@@ -1,15 +1,18 @@
 package site.weather.api.weather.controller;
 
-import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
+import site.weather.api.weather.dto.response.WeatherResponse;
 import site.weather.api.weather.service.WeatherService;
 
 @Controller
@@ -21,12 +24,31 @@ public class WeatherController {
 
 	private final SimpMessagingTemplate messagingTemplate;
 
+	private final Set<String> subscribers = ConcurrentHashMap.newKeySet();
+
+	private WeatherResponse cachedWeatherResponse;
+
 	@MessageMapping("/weather")
 	public void subscribeWeather(String city) {
-		Flux.interval(Duration.ofSeconds(5))
-			.flatMap(tick -> service.fetchWeatherByCity(city))
-			.take(Duration.ofSeconds(30))
+		subscribers.add(city);
+
+		if (cachedWeatherResponse == null) {
+			fetchWeatherByCity(city);
+		}
+	}
+
+	private void fetchWeatherByCity(String city) {
+		service.fetchWeatherByCity(city)
 			.publishOn(Schedulers.boundedElastic())
-			.subscribe(response -> messagingTemplate.convertAndSend("/topic/weather", response));
+			.log()
+			.subscribe(response -> {
+				cachedWeatherResponse = response;
+				messagingTemplate.convertAndSend("/topic/weather/" + city, response);
+			});
+	}
+
+	@Scheduled(fixedRate = 30, timeUnit = TimeUnit.SECONDS)
+	public void fetchAndBroadcastByCity() {
+		subscribers.forEach(this::fetchWeatherByCity);
 	}
 }

--- a/src/main/java/site/weather/api/weather/controller/WeatherController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherController.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import site.weather.api.weather.repository.WeatherSubscriptionInfoRepository;
 import site.weather.api.weather.service.WeatherService;
 
 @Controller
@@ -19,15 +18,15 @@ public class WeatherController {
 
 	private final WeatherService service;
 	private final SimpMessagingTemplate messagingTemplate;
-	private final WeatherSubscriptionInfoRepository repository;
 
 	@MessageMapping("/weather")
 	public void subscribeWeather(String city) {
-		service.computeIfAbsent(city).sendOrFetchWeather(messagingTemplate, city, service::subscribeWeatherByCity);
+		service.computeIfAbsent(city)
+			.sendOrFetchWeather(messagingTemplate, city, service::subscribeWeatherByCity);
 	}
 
 	@Scheduled(fixedRate = 30, timeUnit = TimeUnit.SECONDS)
 	public void fetchAndBroadcastByCity() {
-		repository.findAllCities().forEach(service::subscribeWeatherByCity);
+		service.findAllSubscribedCities().forEach(service::subscribeWeatherByCity);
 	}
 }

--- a/src/main/java/site/weather/api/weather/controller/WeatherController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherController.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import site.weather.api.weather.domain.WeatherSubscriptionInfo;
 import site.weather.api.weather.repository.WeatherSubscriptionInfoRepository;
 import site.weather.api.weather.service.WeatherService;
 
@@ -24,8 +23,7 @@ public class WeatherController {
 
 	@MessageMapping("/weather")
 	public void subscribeWeather(String city) {
-		WeatherSubscriptionInfo weatherSubscriptionInfo = repository.subscribeWeather(city);
-		weatherSubscriptionInfo.sendOrFetchWeather(messagingTemplate, city, service::subscribeWeatherByCity);
+		repository.computeIfAbsent(city).sendOrFetchWeather(messagingTemplate, city, service::subscribeWeatherByCity);
 	}
 
 	@Scheduled(fixedRate = 30, timeUnit = TimeUnit.SECONDS)

--- a/src/main/java/site/weather/api/weather/controller/WeatherController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherController.java
@@ -1,25 +1,19 @@
 package site.weather.api.weather.controller;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import org.springframework.context.event.EventListener;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.socket.messaging.SessionDisconnectEvent;
-import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.scheduler.Schedulers;
 import site.weather.api.weather.domain.WeatherSubscriptionInfo;
+import site.weather.api.weather.repository.WeatherSubscriptionInfoRepository;
 import site.weather.api.weather.service.WeatherService;
 
 @Controller
@@ -33,11 +27,12 @@ public class WeatherController {
 
 	// 도시별 구독 정보
 	private final Map<String, WeatherSubscriptionInfo> weatherSubscriptionInfoMap = new ConcurrentHashMap<>();
+	private final WeatherSubscriptionInfoRepository repository;
 
 	@MessageMapping("/weather")
 	public void subscribeWeather(String city) {
-		weatherSubscriptionInfoMap.computeIfAbsent(city, key -> new WeatherSubscriptionInfo())
-			.sendOrFetchWeather(messagingTemplate, city, this::fetchWeatherByCity);
+		WeatherSubscriptionInfo weatherSubscriptionInfo = repository.subscribeWeather(city);
+		weatherSubscriptionInfo.sendOrFetchWeather(messagingTemplate, city, this::fetchWeatherByCity);
 	}
 
 	private void fetchWeatherByCity(String city) {
@@ -45,60 +40,13 @@ public class WeatherController {
 			.publishOn(Schedulers.boundedElastic())
 			.log()
 			.subscribe(response -> {
-				weatherSubscriptionInfoMap.computeIfPresent(city,
-					(key, weatherSubscriptionInfo) -> {
-						weatherSubscriptionInfo.changeWeatherResponse(response);
-						return weatherSubscriptionInfo;
-					});
+				repository.changeWeatherResponse(city, response);
 				messagingTemplate.convertAndSend("/topic/weather/" + city, response);
 			});
 	}
 
 	@Scheduled(fixedRate = 30, timeUnit = TimeUnit.SECONDS)
 	public void fetchAndBroadcastByCity() {
-		weatherSubscriptionInfoMap.keySet().forEach(this::fetchWeatherByCity);
-	}
-
-	@EventListener
-	public void handleStompConnectedHandler(SessionSubscribeEvent event) {
-		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
-		String destination = headerAccessor.getDestination();
-
-		parseCityFrom(destination).ifPresent(city -> {
-			String sessionId = headerAccessor.getSessionId();
-			// subscribersSessionId에 도시가 없는 경우 새로운 HashSet을 추가
-			weatherSubscriptionInfoMap.computeIfAbsent(city, k -> new WeatherSubscriptionInfo())
-				.addSessionId(sessionId);
-		});
-		log.info("weatherSubscriptionInfoMap: {}", weatherSubscriptionInfoMap);
-	}
-
-	private Optional<String> parseCityFrom(String destination) {
-		if (destination == null) {
-			return Optional.empty();
-		}
-		final String DESTINATION_SPLITTER = "/";
-		String[] parts = destination.split(DESTINATION_SPLITTER);
-		return Optional.of(parts[parts.length - 1]);
-	}
-
-	@EventListener
-	public void handleStompDisconnectedHandler(SessionDisconnectEvent event) {
-		String sessionId = event.getSessionId();
-		List<String> citiesToRemove = new ArrayList<>();
-
-		// 도시별로 sessionId를 제거하고 제거한 Set이 비어있으면 삭제 목록에 추가
-		weatherSubscriptionInfoMap.forEach((city, weatherSubscriptionInfo) -> {
-			weatherSubscriptionInfo.removeSessionId(sessionId);
-			if (weatherSubscriptionInfo.isEmptySessionIds()) {
-				citiesToRemove.add(city);
-			}
-		});
-
-		// 삭제할 도시 목록에서 제거 작업 수행
-		citiesToRemove.forEach(city -> {
-			weatherSubscriptionInfoMap.remove(city);
-			log.info("remove the city " + city);
-		});
+		repository.findAllCities().forEach(this::fetchWeatherByCity);
 	}
 }

--- a/src/main/java/site/weather/api/weather/controller/WeatherController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherController.java
@@ -1,7 +1,5 @@
 package site.weather.api.weather.controller;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -11,7 +9,6 @@ import org.springframework.stereotype.Controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import reactor.core.scheduler.Schedulers;
 import site.weather.api.weather.domain.WeatherSubscriptionInfo;
 import site.weather.api.weather.repository.WeatherSubscriptionInfoRepository;
 import site.weather.api.weather.service.WeatherService;
@@ -22,31 +19,17 @@ import site.weather.api.weather.service.WeatherService;
 public class WeatherController {
 
 	private final WeatherService service;
-
 	private final SimpMessagingTemplate messagingTemplate;
-
-	// 도시별 구독 정보
-	private final Map<String, WeatherSubscriptionInfo> weatherSubscriptionInfoMap = new ConcurrentHashMap<>();
 	private final WeatherSubscriptionInfoRepository repository;
 
 	@MessageMapping("/weather")
 	public void subscribeWeather(String city) {
 		WeatherSubscriptionInfo weatherSubscriptionInfo = repository.subscribeWeather(city);
-		weatherSubscriptionInfo.sendOrFetchWeather(messagingTemplate, city, this::fetchWeatherByCity);
-	}
-
-	private void fetchWeatherByCity(String city) {
-		service.fetchWeatherByCity(city)
-			.publishOn(Schedulers.boundedElastic())
-			.log()
-			.subscribe(response -> {
-				repository.changeWeatherResponse(city, response);
-				messagingTemplate.convertAndSend("/topic/weather/" + city, response);
-			});
+		weatherSubscriptionInfo.sendOrFetchWeather(messagingTemplate, city, service::subscribeWeatherByCity);
 	}
 
 	@Scheduled(fixedRate = 30, timeUnit = TimeUnit.SECONDS)
 	public void fetchAndBroadcastByCity() {
-		repository.findAllCities().forEach(this::fetchWeatherByCity);
+		repository.findAllCities().forEach(service::subscribeWeatherByCity);
 	}
 }

--- a/src/main/java/site/weather/api/weather/controller/WeatherController.java
+++ b/src/main/java/site/weather/api/weather/controller/WeatherController.java
@@ -1,14 +1,19 @@
 package site.weather.api.weather.controller;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.context.event.EventListener;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,8 +31,10 @@ public class WeatherController {
 	private final SimpMessagingTemplate messagingTemplate;
 
 	private final Set<String> subscribers = ConcurrentHashMap.newKeySet();
+	// 도시별 세션 ID 컬렉션
+	private final Map<String, Set<String>> subscribersSessionId = new ConcurrentHashMap<>();
 	private final Map<String, WeatherResponse> cachedWeatherResponses = new ConcurrentHashMap<>();
-	
+
 	@MessageMapping("/weather")
 	public void subscribeWeather(String city) {
 		subscribers.add(city);
@@ -52,5 +59,39 @@ public class WeatherController {
 	@Scheduled(fixedRate = 30, timeUnit = TimeUnit.SECONDS)
 	public void fetchAndBroadcastByCity() {
 		subscribers.forEach(this::fetchWeatherByCity);
+	}
+
+	@EventListener
+	public void handleStompConnectedHandler(SessionSubscribeEvent event) {
+		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = headerAccessor.getSessionId();
+		String destination = headerAccessor.getDestination();
+		if (destination == null) {
+			return;
+		}
+		String[] parts = destination.split("/");
+		String city = parts[parts.length - 1];
+		// subscribersSessionId에 도시가 없는 경우 새로운 HashSet을 추가
+		subscribersSessionId.computeIfAbsent(city, k -> ConcurrentHashMap.newKeySet()).add(sessionId);
+		log.info("subscribersSessionId: {}", subscribersSessionId);
+	}
+
+	@EventListener
+	public void handleStompDisconnectedHandler(SessionDisconnectEvent event) {
+		String sessionId = event.getSessionId();
+		Set<String> delCity = new HashSet<>();
+		// 도시별로 sessionId를 제거하고 제거한 Set이 비어있으면 삭제 집합에 추가한다
+		subscribersSessionId.keySet().forEach(city -> {
+			Set<String> sessionIdSet = subscribersSessionId.getOrDefault(city, new HashSet<>());
+			sessionIdSet.remove(sessionId);
+			if (sessionIdSet.isEmpty()) {
+				delCity.add(city);
+			}
+		});
+		delCity.forEach(city -> {
+			subscribersSessionId.remove(city);
+			subscribers.remove(city);
+			log.info("remove the city " + city);
+		});
 	}
 }

--- a/src/main/java/site/weather/api/weather/domain/WeatherSubscriptionInfo.java
+++ b/src/main/java/site/weather/api/weather/domain/WeatherSubscriptionInfo.java
@@ -2,6 +2,7 @@ package site.weather.api.weather.domain;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
@@ -46,5 +47,14 @@ public class WeatherSubscriptionInfo {
 
 	public boolean hasWeatherResponse() {
 		return weatherResponse != null;
+	}
+
+	public void sendOrFetchWeather(SimpMessagingTemplate messagingTemplate, String city,
+		Consumer<String> fetchWeatherByCity) {
+		if (hasWeatherResponse()) {
+			sendMessage(messagingTemplate, city);
+		} else {
+			fetchWeatherByCity.accept(city);
+		}
 	}
 }

--- a/src/main/java/site/weather/api/weather/domain/WeatherSubscriptionInfo.java
+++ b/src/main/java/site/weather/api/weather/domain/WeatherSubscriptionInfo.java
@@ -1,0 +1,25 @@
+package site.weather.api.weather.domain;
+
+import java.util.Set;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import site.weather.api.weather.dto.response.WeatherResponse;
+
+public class WeatherSubscriptionInfo {
+	private final Set<String> sessionIds;
+	private WeatherResponse weatherResponse;
+
+	public WeatherSubscriptionInfo(Set<String> sessionIds, WeatherResponse weatherResponse) {
+		this.sessionIds = sessionIds;
+		this.weatherResponse = weatherResponse;
+	}
+
+	public void sendMessage(SimpMessagingTemplate messagingTemplate, String city) {
+		messagingTemplate.convertAndSend("/topic/weather/" + city, weatherResponse);
+	}
+
+	public void changeWeatherResponse(WeatherResponse weatherResponse) {
+		this.weatherResponse = weatherResponse;
+	}
+}

--- a/src/main/java/site/weather/api/weather/domain/WeatherSubscriptionInfo.java
+++ b/src/main/java/site/weather/api/weather/domain/WeatherSubscriptionInfo.java
@@ -1,5 +1,6 @@
 package site.weather.api.weather.domain;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -9,6 +10,14 @@ import site.weather.api.weather.dto.response.WeatherResponse;
 public class WeatherSubscriptionInfo {
 	private final Set<String> sessionIds;
 	private WeatherResponse weatherResponse;
+
+	public WeatherSubscriptionInfo() {
+		this(new HashSet<>());
+	}
+
+	public WeatherSubscriptionInfo(Set<String> sessionIds) {
+		this(sessionIds, null);
+	}
 
 	public WeatherSubscriptionInfo(Set<String> sessionIds, WeatherResponse weatherResponse) {
 		this.sessionIds = sessionIds;
@@ -21,5 +30,21 @@ public class WeatherSubscriptionInfo {
 
 	public void changeWeatherResponse(WeatherResponse weatherResponse) {
 		this.weatherResponse = weatherResponse;
+	}
+
+	public void addSessionId(String sessionId) {
+		sessionIds.add(sessionId);
+	}
+
+	public void removeSessionId(String sessionId) {
+		sessionIds.remove(sessionId);
+	}
+
+	public boolean isEmptySessionIds() {
+		return sessionIds.isEmpty();
+	}
+
+	public boolean hasWeatherResponse() {
+		return weatherResponse != null;
 	}
 }

--- a/src/main/java/site/weather/api/weather/event/WeatherEventListener.java
+++ b/src/main/java/site/weather/api/weather/event/WeatherEventListener.java
@@ -10,14 +10,14 @@ import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import site.weather.api.weather.repository.WeatherSubscriptionInfoRepository;
+import site.weather.api.weather.service.WeatherService;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class WeatherEventListener {
 
-	private final WeatherSubscriptionInfoRepository repository;
+	private final WeatherService service;
 
 	@EventListener
 	public void handleStompConnectedHandler(SessionSubscribeEvent event) {
@@ -26,21 +26,17 @@ public class WeatherEventListener {
 
 		parseCityFrom(destination).ifPresent(city -> {
 			String sessionId = headerAccessor.getSessionId();
-			repository.addSessionId(city, sessionId);
+			service.addSessionId(city, sessionId);
 		});
 	}
 
 	private Optional<String> parseCityFrom(String destination) {
-		if (destination == null) {
-			return Optional.empty();
-		}
-		final String DESTINATION_SPLITTER = "/";
-		String[] parts = destination.split(DESTINATION_SPLITTER);
-		return Optional.of(parts[parts.length - 1]);
+		return Optional.ofNullable(destination)
+			.map(dst -> dst.substring(dst.lastIndexOf("/") + 1));
 	}
 
 	@EventListener
 	public void handleStompDisconnectedHandler(SessionDisconnectEvent event) {
-		repository.removeCityIfNoSubscribers(event.getSessionId());
+		service.removeCityIfNoSubscribers(event.getSessionId());
 	}
 }

--- a/src/main/java/site/weather/api/weather/event/WeatherEventListener.java
+++ b/src/main/java/site/weather/api/weather/event/WeatherEventListener.java
@@ -1,0 +1,46 @@
+package site.weather.api.weather.event;
+
+import java.util.Optional;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import site.weather.api.weather.repository.WeatherSubscriptionInfoRepository;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WeatherEventListener {
+
+	private final WeatherSubscriptionInfoRepository repository;
+
+	@EventListener
+	public void handleStompConnectedHandler(SessionSubscribeEvent event) {
+		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+		String destination = headerAccessor.getDestination();
+
+		parseCityFrom(destination).ifPresent(city -> {
+			String sessionId = headerAccessor.getSessionId();
+			repository.addSessionId(city, sessionId);
+		});
+	}
+
+	private Optional<String> parseCityFrom(String destination) {
+		if (destination == null) {
+			return Optional.empty();
+		}
+		final String DESTINATION_SPLITTER = "/";
+		String[] parts = destination.split(DESTINATION_SPLITTER);
+		return Optional.of(parts[parts.length - 1]);
+	}
+
+	@EventListener
+	public void handleStompDisconnectedHandler(SessionDisconnectEvent event) {
+		repository.removeCityIfNoSubscribers(event.getSessionId());
+	}
+}

--- a/src/main/java/site/weather/api/weather/repository/MemoryWeatherSubscriptionInfoRepository.java
+++ b/src/main/java/site/weather/api/weather/repository/MemoryWeatherSubscriptionInfoRepository.java
@@ -60,7 +60,7 @@ public class MemoryWeatherSubscriptionInfoRepository implements WeatherSubscript
 	}
 
 	@Override
-	public Set<String> findAllCities() {
+	public Set<String> findAllSubscribedCities() {
 		return weatherSubscriptionInfoMap.keySet();
 	}
 }

--- a/src/main/java/site/weather/api/weather/repository/MemoryWeatherSubscriptionInfoRepository.java
+++ b/src/main/java/site/weather/api/weather/repository/MemoryWeatherSubscriptionInfoRepository.java
@@ -19,7 +19,7 @@ public class MemoryWeatherSubscriptionInfoRepository implements WeatherSubscript
 	private final Map<String, WeatherSubscriptionInfo> weatherSubscriptionInfoMap = new ConcurrentHashMap<>();
 
 	@Override
-	public WeatherSubscriptionInfo subscribeWeather(String city) {
+	public WeatherSubscriptionInfo computeIfAbsent(String city) {
 		return weatherSubscriptionInfoMap.computeIfAbsent(city, key -> new WeatherSubscriptionInfo());
 	}
 

--- a/src/main/java/site/weather/api/weather/repository/MemoryWeatherSubscriptionInfoRepository.java
+++ b/src/main/java/site/weather/api/weather/repository/MemoryWeatherSubscriptionInfoRepository.java
@@ -1,0 +1,66 @@
+package site.weather.api.weather.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+import site.weather.api.weather.domain.WeatherSubscriptionInfo;
+import site.weather.api.weather.dto.response.WeatherResponse;
+
+@Component
+@Slf4j
+public class MemoryWeatherSubscriptionInfoRepository implements WeatherSubscriptionInfoRepository {
+
+	private final Map<String, WeatherSubscriptionInfo> weatherSubscriptionInfoMap = new ConcurrentHashMap<>();
+
+	@Override
+	public WeatherSubscriptionInfo subscribeWeather(String city) {
+		return weatherSubscriptionInfoMap.computeIfAbsent(city, key -> new WeatherSubscriptionInfo());
+	}
+
+	@Override
+	public void addSessionId(String city, String sessionId) {
+		// 도시가 없는 경우 새로운 객체 추가한 다음에 sessionId 추가
+		weatherSubscriptionInfoMap.computeIfAbsent(city, k -> new WeatherSubscriptionInfo())
+			.addSessionId(sessionId);
+		log.info("add city:{}, sessionId: {}", city, sessionId);
+	}
+
+	@Override
+	public void removeCityIfNoSubscribers(String sessionId) {
+		List<String> citiesToRemove = new ArrayList<>();
+
+		// 도시별로 sessionId를 제거하고 제거한 Set이 비어있으면 삭제 목록에 추가
+		weatherSubscriptionInfoMap.forEach((city, weatherSubscriptionInfo) -> {
+			weatherSubscriptionInfo.removeSessionId(sessionId);
+			if (weatherSubscriptionInfo.isEmptySessionIds()) {
+				citiesToRemove.add(city);
+			}
+		});
+
+		// 삭제할 도시 목록에서 제거 작업 수행
+		citiesToRemove.forEach(city -> {
+			weatherSubscriptionInfoMap.remove(city);
+			log.info("remove the city " + city);
+		});
+	}
+
+	@Override
+	public void changeWeatherResponse(String city, WeatherResponse response) {
+		weatherSubscriptionInfoMap.computeIfPresent(city,
+			(key, subscriptionInfo) -> {
+				subscriptionInfo.changeWeatherResponse(response);
+				return subscriptionInfo;
+			});
+	}
+
+	@Override
+	public Set<String> findAllCities() {
+		return weatherSubscriptionInfoMap.keySet();
+	}
+}

--- a/src/main/java/site/weather/api/weather/repository/WeatherSubscriptionInfoRepository.java
+++ b/src/main/java/site/weather/api/weather/repository/WeatherSubscriptionInfoRepository.java
@@ -1,0 +1,18 @@
+package site.weather.api.weather.repository;
+
+import java.util.Set;
+
+import site.weather.api.weather.domain.WeatherSubscriptionInfo;
+import site.weather.api.weather.dto.response.WeatherResponse;
+
+public interface WeatherSubscriptionInfoRepository {
+	WeatherSubscriptionInfo subscribeWeather(String city);
+
+	void addSessionId(String city, String sessionId);
+
+	void removeCityIfNoSubscribers(String sessionId);
+
+	void changeWeatherResponse(String city, WeatherResponse response);
+
+	Set<String> findAllCities();
+}

--- a/src/main/java/site/weather/api/weather/repository/WeatherSubscriptionInfoRepository.java
+++ b/src/main/java/site/weather/api/weather/repository/WeatherSubscriptionInfoRepository.java
@@ -6,7 +6,7 @@ import site.weather.api.weather.domain.WeatherSubscriptionInfo;
 import site.weather.api.weather.dto.response.WeatherResponse;
 
 public interface WeatherSubscriptionInfoRepository {
-	WeatherSubscriptionInfo subscribeWeather(String city);
+	WeatherSubscriptionInfo computeIfAbsent(String city);
 
 	void addSessionId(String city, String sessionId);
 

--- a/src/main/java/site/weather/api/weather/repository/WeatherSubscriptionInfoRepository.java
+++ b/src/main/java/site/weather/api/weather/repository/WeatherSubscriptionInfoRepository.java
@@ -14,5 +14,5 @@ public interface WeatherSubscriptionInfoRepository {
 
 	void changeWeatherResponse(String city, WeatherResponse response);
 
-	Set<String> findAllCities();
+	Set<String> findAllSubscribedCities();
 }

--- a/src/main/java/site/weather/api/weather/service/WeatherService.java
+++ b/src/main/java/site/weather/api/weather/service/WeatherService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import site.weather.api.weather.domain.WeatherSubscriptionInfo;
 import site.weather.api.weather.dto.response.WeatherResponse;
 import site.weather.api.weather.repository.WeatherSubscriptionInfoRepository;
 
@@ -29,5 +30,9 @@ public class WeatherService {
 				repository.changeWeatherResponse(city, response);
 				messagingTemplate.convertAndSend("/topic/weather/" + city, response);
 			});
+	}
+
+	public WeatherSubscriptionInfo computeIfAbsent(String city) {
+		return repository.computeIfAbsent(city);
 	}
 }

--- a/src/main/java/site/weather/api/weather/service/WeatherService.java
+++ b/src/main/java/site/weather/api/weather/service/WeatherService.java
@@ -41,4 +41,12 @@ public class WeatherService {
 	public Set<String> findAllSubscribedCities() {
 		return repository.findAllSubscribedCities();
 	}
+
+	public void addSessionId(String city, String sessionId) {
+		repository.addSessionId(city, sessionId);
+	}
+
+	public void removeCityIfNoSubscribers(String sessionId) {
+		repository.removeCityIfNoSubscribers(sessionId);
+	}
 }

--- a/src/main/java/site/weather/api/weather/service/WeatherService.java
+++ b/src/main/java/site/weather/api/weather/service/WeatherService.java
@@ -1,5 +1,7 @@
 package site.weather.api.weather.service;
 
+import java.util.Set;
+
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
@@ -34,5 +36,9 @@ public class WeatherService {
 
 	public WeatherSubscriptionInfo computeIfAbsent(String city) {
 		return repository.computeIfAbsent(city);
+	}
+
+	public Set<String> findAllSubscribedCities() {
+		return repository.findAllSubscribedCities();
 	}
 }

--- a/src/main/java/site/weather/api/weather/service/WeatherService.java
+++ b/src/main/java/site/weather/api/weather/service/WeatherService.java
@@ -1,18 +1,33 @@
 package site.weather.api.weather.service;
 
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import site.weather.api.weather.dto.response.WeatherResponse;
+import site.weather.api.weather.repository.WeatherSubscriptionInfoRepository;
 
 @Service
 @RequiredArgsConstructor
 public class WeatherService {
 
 	private final WeatherWebClient client;
+	private final WeatherSubscriptionInfoRepository repository;
+	private final SimpMessagingTemplate messagingTemplate;
 
 	public Mono<WeatherResponse> fetchWeatherByCity(String city) {
 		return client.fetchWeatherByCity(city);
+	}
+
+	public void subscribeWeatherByCity(String city) {
+		client.fetchWeatherByCity(city)
+			.publishOn(Schedulers.boundedElastic())
+			.log()
+			.subscribe(response -> {
+				repository.changeWeatherResponse(city, response);
+				messagingTemplate.convertAndSend("/topic/weather/" + city, response);
+			});
 	}
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -97,9 +97,10 @@
     async function getWeather() {
         const socket = new SockJS('/ws/weather');
         const stompClient = Stomp.over(socket);
+        const city = document.querySelector("#city").value;
 
         stompClient.connect({}, () => {
-            stompClient.subscribe('/topic/weather', (message) => {
+            stompClient.subscribe('/topic/weather/' + city, (message) => {
                 const weatherData = JSON.parse(message.body);
                 document.querySelector("#result").innerHTML = `
                 <p>City: ${weatherData.name}</p>
@@ -107,7 +108,7 @@
             });
 
             // 특정 도시를 구독
-            stompClient.send("/app/weather", {}, "Seoul");
+            stompClient.send("/app/weather", {}, city);
         });
     }
 </script>


### PR DESCRIPTION
## 구현한것
- 기존 Controller에 정의된 기능들을 역할별로 클래스 분리(Service, Repository, EventListener 등)
- 사용자가 세션을 연결 해제하는 경우 도시별 구독 관리 맵에서 사용자의 세션을 제거하도록 구현
  - 구독자가 없는 도시 같은 경우에는 API 호출되지 않도록 key(city)를 제거함
- 스케줄링 주기를 5초간격으로 변경

## TO-BE
- WeatherWebClient.fetchWeatherByCity 메서드에 캐싱 10분 적용
  - 10분인 이유는 openweather 사이트에서 데이터를 10분 간격으로 업데이트하기 때문
  - 그러나 실제 10분인지 확인이 한번 필요함