### PR TITLE
[feat] 캐싱 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/site/weather/api/weather/domain/WeatherSubscriptionInfo.java
+++ b/src/main/java/site/weather/api/weather/domain/WeatherSubscriptionInfo.java
@@ -6,8 +6,10 @@ import java.util.function.Consumer;
 
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
+import lombok.extern.slf4j.Slf4j;
 import site.weather.api.weather.dto.response.WeatherResponse;
 
+@Slf4j
 public class WeatherSubscriptionInfo {
 	private final Set<String> sessionIds;
 	private WeatherResponse weatherResponse;
@@ -35,6 +37,7 @@ public class WeatherSubscriptionInfo {
 
 	public void addSessionId(String sessionId) {
 		sessionIds.add(sessionId);
+		log.info("add sessionId: {}", sessionId);
 	}
 
 	public void removeSessionId(String sessionId) {

--- a/src/main/java/site/weather/api/weather/event/WeatherEventListener.java
+++ b/src/main/java/site/weather/api/weather/event/WeatherEventListener.java
@@ -46,5 +46,6 @@ public class WeatherEventListener {
 	@EventListener
 	public void handleStompDisconnectedHandler(SessionDisconnectEvent event) {
 		service.removeCityIfNoSubscribers(event.getSessionId());
+		log.info("disconnect sessionId={}", event.getSessionId());
 	}
 }

--- a/src/main/java/site/weather/api/weather/event/WeatherEventListener.java
+++ b/src/main/java/site/weather/api/weather/event/WeatherEventListener.java
@@ -7,6 +7,7 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +34,13 @@ public class WeatherEventListener {
 	private Optional<String> parseCityFrom(String destination) {
 		return Optional.ofNullable(destination)
 			.map(dst -> dst.substring(dst.lastIndexOf("/") + 1));
+	}
+
+	@EventListener
+	public void handleStompUnsubscribeHandler(SessionUnsubscribeEvent event) {
+		StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = headerAccessor.getSessionId();
+		service.removeCityIfNoSubscribers(sessionId);
 	}
 
 	@EventListener

--- a/src/main/java/site/weather/api/weather/repository/MemoryWeatherSubscriptionInfoRepository.java
+++ b/src/main/java/site/weather/api/weather/repository/MemoryWeatherSubscriptionInfoRepository.java
@@ -28,7 +28,6 @@ public class MemoryWeatherSubscriptionInfoRepository implements WeatherSubscript
 		// 도시가 없는 경우 새로운 객체 추가한 다음에 sessionId 추가
 		weatherSubscriptionInfoMap.computeIfAbsent(city, k -> new WeatherSubscriptionInfo())
 			.addSessionId(sessionId);
-		log.info("add city:{}, sessionId: {}", city, sessionId);
 	}
 
 	@Override

--- a/src/main/java/site/weather/api/weather/service/WeatherService.java
+++ b/src/main/java/site/weather/api/weather/service/WeatherService.java
@@ -27,7 +27,6 @@ public class WeatherService {
 	public void subscribeWeatherByCity(String city) {
 		client.fetchWeatherByCity(city)
 			.publishOn(Schedulers.boundedElastic())
-			.log()
 			.subscribe(response -> {
 				repository.changeWeatherResponse(city, response);
 				messagingTemplate.convertAndSend("/topic/weather/" + city, response);

--- a/src/main/java/site/weather/api/weather/service/WeatherWebClient.java
+++ b/src/main/java/site/weather/api/weather/service/WeatherWebClient.java
@@ -1,5 +1,6 @@
 package site.weather.api.weather.service;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import reactor.core.publisher.Mono;
@@ -15,6 +16,7 @@ public class WeatherWebClient {
 		this.appid = appid;
 	}
 
+	@Cacheable(value = "weatherCache", key = "#city")
 	public Mono<WeatherResponse> fetchWeatherByCity(String city) {
 		return webClient.get()
 			.uri(uriBuilder -> uriBuilder

--- a/src/main/java/site/weather/api/weather/service/WeatherWebClient.java
+++ b/src/main/java/site/weather/api/weather/service/WeatherWebClient.java
@@ -3,10 +3,12 @@ package site.weather.api.weather.service;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 import site.weather.api.weather.domain.Units;
 import site.weather.api.weather.dto.response.WeatherResponse;
 
+@Slf4j
 public class WeatherWebClient {
 	private final WebClient webClient;
 	private final String appid;
@@ -18,6 +20,7 @@ public class WeatherWebClient {
 
 	@Cacheable(value = "weatherCache", key = "#city")
 	public Mono<WeatherResponse> fetchWeatherByCity(String city) {
+		log.info("call fetchWeatherByCity, city={}", city);
 		return webClient.get()
 			.uri(uriBuilder -> uriBuilder
 				.path("/data/2.5/weather")

--- a/src/main/java/site/weather/global/config/CacheConfig.java
+++ b/src/main/java/site/weather/global/config/CacheConfig.java
@@ -1,0 +1,29 @@
+package site.weather.global.config;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+	@Bean
+	public CaffeineCacheManager cacheManager() {
+		CaffeineCacheManager cacheManager = new CaffeineCacheManager("weatherCache");
+		cacheManager.setCaffeine(caffeineCacheBuilder());
+		cacheManager.setAsyncCacheMode(true);
+		return cacheManager;
+	}
+
+	@Bean
+	public Caffeine<Object, Object> caffeineCacheBuilder() {
+		return Caffeine.newBuilder()
+			.expireAfterWrite(10, TimeUnit.MINUTES)
+			.maximumSize(100);
+	}
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -88,19 +88,26 @@
     <label for="city">Enter City Name:</label>
     <input type="text" id="city" name="city" value="Seoul" required>
     <button type="button" onclick="getWeather()">Get Weather</button>
+    <button type="button" onclick="cancelWeather()">Cancel</button>
 </form>
 
 
 <div id="result"></div>
 
 <script>
+    let stompClient;
+    let subscription;
+
     async function getWeather() {
         const socket = new SockJS('/ws/weather');
-        const stompClient = Stomp.over(socket);
+        stompClient = Stomp.over(socket);
         const city = document.querySelector("#city").value;
 
         stompClient.connect({}, () => {
-            stompClient.subscribe('/topic/weather/' + city, (message) => {
+            if (subscription) {
+                subscription.unsubscribe();
+            }
+            subscription = stompClient.subscribe('/topic/weather/' + city, (message) => {
                 const weatherData = JSON.parse(message.body);
                 document.querySelector("#result").innerHTML = `
                 <p>City: ${weatherData.name}</p>
@@ -110,6 +117,14 @@
             // 특정 도시를 구독
             stompClient.send("/app/weather", {}, city);
         });
+    }
+
+    async function cancelWeather() {
+        if (subscription) {
+            subscription.unsubscribe();
+            console.log("Unsubscribed from the weather topic.");
+            subscription = null; // 구독 ID 초기화
+        }
     }
 </script>
 


### PR DESCRIPTION
## 구현한것
- 카페인 캐싱 설정 
  - 카페인 캐시를 추가한 이유는 로컬 캐시이고 ehcache 라이브러리보다 높은 성능을 보입니다.
  - Mono, Flux와 같은 Reactive Type에 대해서 캐싱 가능 
- 날씨 API 조회하는 메서드에 캐싱 추가 (TTL:10분)
  - 10분 이유는 openweather에서 데이터 업데이트 주기가 10분이기 때문
- index.html에 구독 해제 버튼 추가 

## 성능 측정 결과
10명의 사용자가 1분 동안 도시 날씨 웹소켓 연결을 수행합니다. 메시지를 수신하고 2~5초 대기하고 웹소켓 연결을 종료합니다.

**수치변화**
- Throughput : { 10.9/sec } -> { 11.3/sec}
